### PR TITLE
(#27) Implemented ignorePlayerDamageFromMagmaBlock rule

### DIFF
--- a/src/main/java/com/johanvonelectrum/johan_carpet/JohanSettings.java
+++ b/src/main/java/com/johanvonelectrum/johan_carpet/JohanSettings.java
@@ -3,6 +3,7 @@ package com.johanvonelectrum.johan_carpet;
 import carpet.settings.ParsedRule;
 import carpet.settings.Rule;
 import carpet.settings.Validator;
+import carpet.utils.Messenger;
 import net.minecraft.server.command.ServerCommandSource;
 
 import java.util.Arrays;
@@ -59,9 +60,9 @@ public class JohanSettings {
 
         @Override
         public String validate(ServerCommandSource serverCommandSource, ParsedRule<String> parsedRule, String s, String s2) {
-            if ((serverCommandSource == null || parsedRule.get().equals(s)) && Arrays.asList(keepProjectilesTickedOptions).contains(s))
-                keepProjectilesTicked = s;
-            return s;
+            if (Arrays.asList(keepProjectilesTickedOptions).contains(s))
+                return s;
+            return null;
         }
     }
     /* End keepProjectilesTicked stuff */
@@ -224,9 +225,9 @@ public class JohanSettings {
 
         @Override
         public String validate(ServerCommandSource serverCommandSource, ParsedRule<String> parsedRule, String s, String s2) {
-            if ((serverCommandSource == null || parsedRule.get().equals(s)) && Arrays.asList(carefulBreakOptions).contains(s))
-                carefulBreak = s;
-            return s;
+            if (Arrays.asList(carefulBreakOptions).contains(s))
+                return s;
+            return null;
         }
     }
     /* End CarefulBreak stuff */
@@ -333,11 +334,32 @@ public class JohanSettings {
     )
     public static boolean zeroTickFarms = false;
 
+
+    /* Begin magmaBlockDamage stuff */
+    private static final String[] magmaBlockDamageOptions = new String[] { "always", "only-mobs", "never" };
     @Rule(
-            desc = "Ignores magma block damage to players.",
-            category = { johanSettingsCategory, SURVIVAL, CHEAT }
+            desc = ".",
+            category = { johanSettingsCategory, SURVIVAL, CHEAT },
+            options = { "always", "only-mobs", "never" },
+            validate = { magmaBlockDamageValidator.class }
     )
-    public static boolean ignorePlayerDamageFromMagmaBlock = false;
+    public static String magmaBlockDamage = "always";
+
+    private static class magmaBlockDamageValidator extends Validator<String> {
+
+        @Override
+        public String validate(ServerCommandSource source, ParsedRule<String> currentRule, String newValue, String string) {
+            if (Arrays.asList(magmaBlockDamageOptions).contains(newValue))
+                return newValue;
+            return null;
+        }
+
+        @Override
+        public void notifyFailure(ServerCommandSource source, ParsedRule<String> currentRule, String providedValue) {
+            Messenger.m(source, "r Wrong value for " + currentRule.name + ": " + providedValue + ". Chose one from \"always\", \"only-mobs\", \"never\"");
+        }
+    }
+    /* End magmaBlockDamage stuff */
 
     /* ===== End PlayerTweaks Rules =====*/
 

--- a/src/main/java/com/johanvonelectrum/johan_carpet/JohanSettings.java
+++ b/src/main/java/com/johanvonelectrum/johan_carpet/JohanSettings.java
@@ -333,6 +333,12 @@ public class JohanSettings {
     )
     public static boolean zeroTickFarms = false;
 
+    @Rule(
+            desc = "Ignores magma block damage to players.",
+            category = { johanSettingsCategory, SURVIVAL, CHEAT }
+    )
+    public static boolean ignorePlayerDamageFromMagmaBlock = false;
+
     /* ===== End PlayerTweaks Rules =====*/
 
 }

--- a/src/main/java/com/johanvonelectrum/johan_carpet/mixins/MagmaBlockMixin.java
+++ b/src/main/java/com/johanvonelectrum/johan_carpet/mixins/MagmaBlockMixin.java
@@ -1,0 +1,39 @@
+package com.johanvonelectrum.johan_carpet.mixins;
+
+import com.johanvonelectrum.johan_carpet.JohanSettings;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.MagmaBlock;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MagmaBlock.class)
+public class MagmaBlockMixin extends Block {
+    public MagmaBlockMixin(Settings settings) {
+        super(settings);
+    }
+
+    @Inject(method = "onSteppedOn", at = @At("HEAD"), cancellable = true)
+    public void avoidPlayerDamage(World world, BlockPos pos, BlockState state, Entity entity, CallbackInfo ci) {
+        ci.cancel();
+        boolean shouldDamagePlayer = !entity.isFireImmune() && entity instanceof LivingEntity && !EnchantmentHelper.hasFrostWalker((LivingEntity)entity);
+        if (JohanSettings.ignorePlayerDamageFromMagmaBlock) {
+            shouldDamagePlayer = shouldDamagePlayer && !(entity instanceof PlayerEntity);
+        }
+
+        if (shouldDamagePlayer) {
+            entity.damage(DamageSource.HOT_FLOOR, 1.0F);
+        }
+
+        super.onSteppedOn(world, pos, state, entity);
+    }
+}

--- a/src/main/java/com/johanvonelectrum/johan_carpet/mixins/MagmaBlockMixin.java
+++ b/src/main/java/com/johanvonelectrum/johan_carpet/mixins/MagmaBlockMixin.java
@@ -22,18 +22,11 @@ public class MagmaBlockMixin extends Block {
         super(settings);
     }
 
-    @Inject(method = "onSteppedOn", at = @At("HEAD"), cancellable = true)
-    public void avoidPlayerDamage(World world, BlockPos pos, BlockState state, Entity entity, CallbackInfo ci) {
-        ci.cancel();
-        boolean shouldDamagePlayer = !entity.isFireImmune() && entity instanceof LivingEntity && !EnchantmentHelper.hasFrostWalker((LivingEntity)entity);
-        if (JohanSettings.ignorePlayerDamageFromMagmaBlock) {
-            shouldDamagePlayer = shouldDamagePlayer && !(entity instanceof PlayerEntity);
+    @Inject(method = "onSteppedOn", at = @At("INVOKE"), cancellable = true)
+    public void onSteppedOn(World world, BlockPos pos, BlockState state, Entity entity, CallbackInfo ci) {
+        if ((JohanSettings.magmaBlockDamage.equals("only-mobs") && entity instanceof PlayerEntity) || JohanSettings.magmaBlockDamage.equals("never")) {
+            ci.cancel();
+            super.onSteppedOn(world, pos, state, entity);
         }
-
-        if (shouldDamagePlayer) {
-            entity.damage(DamageSource.HOT_FLOOR, 1.0F);
-        }
-
-        super.onSteppedOn(world, pos, state, entity);
     }
 }

--- a/src/main/resources/johan_carpet.mixins.json
+++ b/src/main/resources/johan_carpet.mixins.json
@@ -38,7 +38,8 @@
         "zeroTickFarms.BambooBlockMixin",
         "zeroTickFarms.CactusBlockMixin",
         "zeroTickFarms.ChorusFlowerBlockMixin",
-        "zeroTickFarms.SugarCaneBlockMixin"
+        "zeroTickFarms.SugarCaneBlockMixin",
+        "MagmaBlockMixin"
     ],
     "client": [
         "MinecraftClientMixin"


### PR DESCRIPTION
Implementado rule para evitar que el jugador reciba daño de los magma blocks.
Relacionado con la issue #27.